### PR TITLE
Adjust visible light control in TimeOfDayTest

### DIFF
--- a/src/engine/client/library/clientGame/src/shared/test/TimeOfDayTest.cpp
+++ b/src/engine/client/library/clientGame/src/shared/test/TimeOfDayTest.cpp
@@ -29,7 +29,7 @@ namespace
 	float   m_cycleTime    = 5.f;
 	Timer   m_timer (m_cycleTime);
 	
-	Object* m_mainLight    = 0;
+       Light*  m_mainLight    = 0;
 	float   m_mainYaw      = 0.f;
 	Object* m_fillLight    = 0;
 	float   m_fillYaw      = 0.f;
@@ -46,9 +46,10 @@ TimeOfDayTest::TimeOfDayTest () :
 	ShadowManager::setMeshShadowsVolumetric (true);
 	ShadowManager::setSkeletalShadowsVolumetric (true);
 
-	m_mainLight   = new Object ();
-	m_fillLight   = new Object ();
-	m_bounceLight = new Object ();
+       m_mainLight   = new Light (Light::T_parallel, VectorArgb::solidWhite);
+       m_light       = m_mainLight;
+       m_fillLight   = new Object ();
+       m_bounceLight = new Object ();
 }
 
 //-------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- create the main light as a `Light` instance and set `m_light` to point at it so the base class controls it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68527fe8d9c08320b03f76bc4d87c39e