### PR TITLE
Fix typo 'caracter' in libxml comments

### DIFF
--- a/src/external/3rd/library/libxml/genUnicode.py
+++ b/src/external/3rd/library/libxml/genUnicode.py
@@ -193,7 +193,7 @@ for block in keys:
 header.write("\nint\txmlUCSIsBlock\t(int code,\n\t\t\t const char *block);\n\n")
 output.write("/**\n * xmlUCSIsBlock:\n * @code: UCS code point\n")
 output.write(" * @block: UCS block name\n")
-output.write(" *\n * Check whether the caracter is part of the UCS Block\n")
+output.write(" *\n * Check whether the character is part of the UCS Block\n")
 output.write(" *\n * Returns 1 if true, 0 if false and -1 on unknown block\n */\n");
 output.write("int\nxmlUCSIsBlock(int code, const char *block) {\n")
 keys = BlockNames.keys()
@@ -233,7 +233,7 @@ for name in keys:
 header.write("\nint\txmlUCSIsCat\t(int code,\n\t\t\t const char *cat);\n")
 output.write("/**\n * xmlUCSIsCat:\n * @code: UCS code point\n")
 output.write(" * @cat: UCS Category name\n")
-output.write(" *\n * Check whether the caracter is part of the UCS Category\n")
+output.write(" *\n * Check whether the character is part of the UCS Category\n")
 output.write(" *\n * Returns 1 if true, 0 if false and -1 on unknown category\n */\n");
 output.write("int\nxmlUCSIsCat(int code, const char *cat) {\n")
 keys = Categories.keys()

--- a/src/external/3rd/library/libxml/xmlunicode.c
+++ b/src/external/3rd/library/libxml/xmlunicode.c
@@ -1273,7 +1273,7 @@ xmlUCSIsYiSyllables(int code) {
  * @code: UCS code point
  * @block: UCS block name
  *
- * Check whether the caracter is part of the UCS Block
+ * Check whether the character is part of the UCS Block
  *
  * Returns 1 if true, 0 if false and -1 on unknown block
  */
@@ -4205,7 +4205,7 @@ xmlUCSIsCatZs(int code) {
  * @code: UCS code point
  * @cat: UCS Category name
  *
- * Check whether the caracter is part of the UCS Category
+ * Check whether the character is part of the UCS Category
  *
  * Returns 1 if true, 0 if false and -1 on unknown category
  */


### PR DESCRIPTION
## Summary
- fix typo in libxml generated comments

## Testing
- `python3 -m py_compile src/external/3rd/library/libxml/genUnicode.py` *(fails: SyntaxError)*
- `python2 -m py_compile src/external/3rd/library/libxml/genUnicode.py` *(fails: command not found)*