### PR TITLE
Disable roadmap system

### DIFF
--- a/src/engine/client/library/clientGame/include/public/clientGame/SkillTreeManager.h
+++ b/src/engine/client/library/clientGame/include/public/clientGame/SkillTreeManager.h
@@ -1,0 +1,38 @@
+#ifndef INCLUDED_SkillTreeManager_H
+#define INCLUDED_SkillTreeManager_H
+
+#include <string>
+#include <vector>
+
+class SkillObject;
+
+class SkillTreeManager
+{
+public:
+    typedef std::vector<std::string> SkillVector;
+
+    static void install();
+    static void remove();
+
+    static bool isInstalled();
+
+    // Returns the list of skills that belong to the given template.
+    static SkillVector const &getSkillsForTemplate(std::string const &templateName);
+
+private:
+    SkillTreeManager();
+    ~SkillTreeManager();
+
+    static void loadTemplateDatatable();
+
+    struct TemplateRecord
+    {
+        SkillVector skills;
+    };
+
+    typedef std::map<uint32, TemplateRecord> TemplateMap;
+    static TemplateMap ms_templates;
+    static bool ms_installed;
+};
+
+#endif

--- a/src/engine/client/library/clientGame/src/shared/core/RoadmapManager.cpp
+++ b/src/engine/client/library/clientGame/src/shared/core/RoadmapManager.cpp
@@ -107,11 +107,13 @@ using namespace RoadmapManagerNamespace;
 
 void RoadmapManager::install()
 {
-	loadSkillClientDatatable();
-	loadTemplateDatatable();
-	loadRoadmapDatatable();
-	loadColorForSkillDatatable();
-	loadItemRewardsDatatable();
+    // Load only the data needed for skill templates and icons.  The
+    // roadmap specific tables are skipped so the system behaves like
+    // the classic pre-NGE skill tree.
+    loadSkillClientDatatable();
+    loadTemplateDatatable();
+
+    m_numberOfRoadmaps = 0; // no roadmaps available
 }
 
 //----------------------------------------------------------------------
@@ -708,20 +710,10 @@ void RoadmapManager::getRoadmapList(stdvector<std::string>::fwd &out)
 	
 bool RoadmapManager::playerIsOnRoadmap()
 {
-	PlayerObject const * player = Game::getPlayerObject();
-	if(!player)
-	{
-		return false;
-	}
-	std::string const & templateName = CuiSkillManager::getSkillTemplate();
-
-	
-	if(templateName.empty() || RoadmapManager::getNumberOfBranchesInRoadmap(RoadmapManager::getRoadmapNameForTemplateName(templateName)) == -1 ||
-		RoadmapManager::getPlayerBranch() == -1)
-	{
-		return false;
-	}
-	return true;
+    // Roadmaps are disabled; characters are never considered to be on
+    // a roadmap.  Returning false will bypass all roadmap UI and logic
+    // in favour of the classic skill tree system.
+    return false;
 }
 
 //----------------------------------------------------------------------

--- a/src/engine/client/library/clientGame/src/shared/core/SkillTreeManager.cpp
+++ b/src/engine/client/library/clientGame/src/shared/core/SkillTreeManager.cpp
@@ -1,0 +1,98 @@
+//======================================================================
+//
+// SkillTreeManager.cpp
+// A minimal manager for the classic pre-NGE skill tree system.
+// It parses the skill_template datatable to determine which skills
+// belong to each profession template.
+//
+//======================================================================
+
+#include "clientGame/FirstClientGame.h"
+#include "clientGame/SkillTreeManager.h"
+
+#include "sharedFoundation/Crc.h"
+#include "sharedUtility/DataTable.h"
+#include "sharedUtility/DataTableManager.h"
+
+#include <map>
+
+//----------------------------------------------------------------------
+namespace SkillTreeManagerNamespace
+{
+    SkillTreeManager::TemplateMap ms_templates;
+    bool ms_installed = false;
+}
+using namespace SkillTreeManagerNamespace;
+
+//----------------------------------------------------------------------
+void SkillTreeManager::install()
+{
+    if (ms_installed)
+        return;
+
+    loadTemplateDatatable();
+    ms_installed = true;
+}
+
+//----------------------------------------------------------------------
+void SkillTreeManager::remove()
+{
+    ms_templates.clear();
+    ms_installed = false;
+}
+
+//----------------------------------------------------------------------
+bool SkillTreeManager::isInstalled()
+{
+    return ms_installed;
+}
+
+//----------------------------------------------------------------------
+SkillTreeManager::SkillVector const &SkillTreeManager::getSkillsForTemplate(std::string const &templateName)
+{
+    static SkillVector emptyVector;
+    TemplateMap::const_iterator i = ms_templates.find(Crc::normalizeAndCalculate(templateName.c_str()));
+    if (i != ms_templates.end())
+        return i->second.skills;
+
+    return emptyVector;
+}
+
+//----------------------------------------------------------------------
+void SkillTreeManager::loadTemplateDatatable()
+{
+    // This datatable is shared with the RoadmapManager and lists the
+    // skill boxes associated with each profession template.
+    DataTable *datatable = DataTableManager::getTable("datatables/skill_template/skill_template.iff", true);
+    if (!datatable)
+        return;
+
+    unsigned int const numRows = static_cast<unsigned int>(datatable->getNumRows());
+    int const templateNameColumn = datatable->findColumnNumber("templateName");
+    int const templateColumn = datatable->findColumnNumber("template");
+
+    for (unsigned int r = 0; r < numRows; ++r)
+    {
+        std::string const & templateName = datatable->getStringValue(templateNameColumn, r);
+        std::string const & templateList = datatable->getStringValue(templateColumn, r);
+
+        TemplateRecord rec;
+
+        // Parse the comma separated skill list
+        std::string::size_type curPos = 0;
+        while (curPos != std::string::npos)
+        {
+            std::string::size_type nextPos = templateList.find(',', curPos);
+            std::string skillName = templateList.substr(curPos, nextPos - curPos);
+            if (!skillName.empty())
+                rec.skills.push_back(skillName);
+            curPos = nextPos;
+            if (curPos != std::string::npos)
+                ++curPos;
+        }
+
+        ms_templates.insert(std::make_pair(Crc::normalizeAndCalculate(templateName.c_str()), rec));
+    }
+}
+
+//======================================================================


### PR DESCRIPTION
## Summary
- skip roadmap datatables for a pre-NGE skill tree
- always report that the player is not on a roadmap
- add a minimal SkillTreeManager for profession templates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685407d597788320b4ba914315071b00